### PR TITLE
Account for extra form classes

### DIFF
--- a/templates/Includes/Form.ss
+++ b/templates/Includes/Form.ss
@@ -1,5 +1,5 @@
 <% if IncludeFormTag %>
-<form class="form-horizontal" $AttributesHTML>
+<form $getAttributesHTML(class) class="form-horizontal $extraClass">
 <% end_if %>
 	<% if Message %>
 	<div id="{$FormName}_error" class="alert alert-error message $MessageType">


### PR DESCRIPTION
The original code didn't account for extra classes added in by plugins or "addExtraClass" and therefore, the form code would have two class attributes. This isn't valid HTML and creates issues. So I've excluded the class attribute from the Attributes and then added it manually with the extraClass variable at the end.
